### PR TITLE
Add filtering based on node type to the Gantt chart/calendar

### DIFF
--- a/contrib/horizon/blazardashboard/api/blazar.py
+++ b/contrib/horizon/blazardashboard/api/blazar.py
@@ -207,6 +207,7 @@ def reservation_calendar(request):
         l.project_id,
         l.start_date,
         l.end_date,
+        r.id,
         r.status,
         c.hypervisor_hostname
     FROM

--- a/contrib/horizon/blazardashboard/api/blazar.py
+++ b/contrib/horizon/blazardashboard/api/blazar.py
@@ -201,7 +201,28 @@ def node_type_map(cursor=None):
 def reservation_calendar(request):
     """Return a list of all scheduled leases."""
     cursor = connections['blazar'].cursor()
-    cursor.execute('SELECT l.name, l.project_id, l.start_date, l.end_date, r.id, r.status, c.hypervisor_hostname FROM computehost_allocations cha JOIN computehosts c ON c.id = cha.compute_host_id JOIN reservations r ON r.id = cha.reservation_id JOIN leases l ON l.id = r.lease_id WHERE r.deleted="0" AND c.deleted="0" ORDER BY start_date, project_id')
+    sql = '''\
+    SELECT
+        l.name,
+        l.project_id,
+        l.start_date,
+        l.end_date,
+        r.status,
+        c.hypervisor_hostname
+    FROM
+        computehost_allocations cha
+        JOIN computehosts c ON c.id = cha.compute_host_id
+        JOIN reservations r ON r.id = cha.reservation_id
+        JOIN leases l ON l.id = r.lease_id
+    WHERE
+        r.deleted = '0'
+        AND c.deleted = '0'
+        AND cha.deleted = '0'
+    ORDER BY
+        start_date,
+        project_id;
+    '''
+    cursor.execute(sql)
     host_reservations = dictfetchall(cursor)
 
     return host_reservations

--- a/contrib/horizon/blazardashboard/dashboards/project/leases/static/leases/js/lease_gantt.js
+++ b/contrib/horizon/blazardashboard/dashboards/project/leases/static/leases/js/lease_gantt.js
@@ -153,6 +153,18 @@
         redraw();
       }
     });
+
+    $('.gantt-quickdays').click(function() {
+      var days = $(this).data("gantt-days");
+      var padFraction = 1/8; // gantt chart default is 3 hours for 1 day
+      var timeDomain = [
+        d3.time.day.offset(Date.now(), -days * padFraction),
+        d3.time.day.offset(Date.now(), days * (1 + padFraction))
+      ];
+      setTimeDomain(timeDomain);
+      gantt.timeDomain(timeDomain);
+      redraw();
+    });
   }
 
   horizon.addInitFunction(init);

--- a/contrib/horizon/blazardashboard/dashboards/project/leases/static/leases/js/lease_gantt.js
+++ b/contrib/horizon/blazardashboard/dashboards/project/leases/static/leases/js/lease_gantt.js
@@ -3,6 +3,7 @@
 
   function init() {
     var gantt;
+    var all_tasks;
     var tasks;
     var hosts;
     var form;
@@ -29,7 +30,7 @@
         ['arm64', 'ARM64'],
       ];
 
-      tasks = resp.reservations.map(function(reservation, i) {
+      all_tasks = resp.reservations.map(function(reservation, i) {
         reservation.hosts = resp.reservations.filter(
           function(r) {
             return r.id === this.id;
@@ -45,7 +46,7 @@
           'data': reservation
         }
       });
-
+      tasks = all_tasks;
       hosts = resp.compute_hosts;
 
       // populate node-type-chooser
@@ -66,7 +67,7 @@
 
       $('#blazar-gantt').empty().height(20 * taskNames.length);
       gantt = d3.gantt({
-        selector:'#blazar-gantt',
+        selector: '#blazar-gantt',
         taskTypes: taskNames,
         taskStatus: taskStatus,
         tickFormat: format
@@ -125,15 +126,20 @@
         .filter(function (host) {return nodeType === '*' || nodeType === host.node_type})
         .map(function (host) {return host.hypervisor_hostname});
 
+      tasks = all_tasks.filter(function(task) {
+        return filteredTaskNames.indexOf(task.taskName) >= 0
+      });
+
       $('#blazar-gantt').empty().height(20 * filteredTaskNames.length);
       gantt = d3.gantt({
-        selector:'#blazar-gantt',
+        selector: '#blazar-gantt',
         taskTypes: filteredTaskNames,
         taskStatus: taskStatus,
-        tickFormat: format
+        tickFormat: format,
+        timeDomainStart: timeDomain[0],
+        timeDomainEnd: timeDomain[1],
       });
       gantt(tasks);
-      gantt.timeDomain(timeDomain);
     });
 
     $('input', form).on('change', function() {

--- a/contrib/horizon/blazardashboard/dashboards/project/leases/static/leases/scss/calendar.scss
+++ b/contrib/horizon/blazardashboard/dashboards/project/leases/static/leases/scss/calendar.scss
@@ -51,3 +51,11 @@ line.time-now {
 .gantt-group {
   margin: 5px;
 }
+
+.form-control.gantt-datebox-date {
+  width: 120px;
+}
+
+.form-control.gantt-datebox-hour {
+  width: 55px;
+}

--- a/contrib/horizon/blazardashboard/dashboards/project/leases/static/leases/scss/calendar.scss
+++ b/contrib/horizon/blazardashboard/dashboards/project/leases/static/leases/scss/calendar.scss
@@ -47,3 +47,7 @@ line.time-now {
   stroke-width: 2;
   shape-rendering: crispEdges;
 }
+
+.gantt-group {
+  margin: 5px;
+}

--- a/contrib/horizon/blazardashboard/dashboards/project/leases/templates/leases/calendar.html
+++ b/contrib/horizon/blazardashboard/dashboards/project/leases/templates/leases/calendar.html
@@ -7,22 +7,26 @@
 {% endblock page_header %}
 
 {% block main %}
-  <h4>Display Date Range</h4>
   <form class="form-inline" name="blazar-gantt-controls">
-    <div class="form-group">
+    <div class="form-group gantt-group">
       <label for="dateStart">Start</label>
       <input class="form-control" type="text" name="dateStart" id="dateStart" style="width:120px" placeholder="MM/DD/YYYY">
       <input class="form-control" type="number" min="00" max="23" name="timeStartHours" id="timeStartHours" style="width:55px" placeholder="hh">
       :
-      <input class="form-control" type="number" min="00" max="59" name="timeStartMinutes" id="timeStartMinutes" style="width:55px" placeholder="mm">
+      00
     </div>
-    &nbsp;
-    <div class="form-group">
+    <div class="form-group gantt-group">
       <label for="dateEnd">End</label>
       <input class="form-control" type="text" name="dateEnd" id="dateEnd" style="width:120px" placeholder="MM/DD/YYYY">
       <input class="form-control" type="number" min="00" max="23" name="timeEndHours" id="timeEndHours" style="width:55px" placeholder="hh">
       :
-      <input class="form-control" type="number" min="00" max="59" name="timeEndMinutes" id="timeEndMinutes" style="width:55px" placeholder="mm">
+      00
+    </div>
+    <div class="form-group gantt-group">
+      <label for="node-type-chooser">Node Type</label>
+      <select disabled class="form-control" id="node-type-chooser" name="node-type-chooser">
+        <option value="*">All nodes</option>
+      </select>
     </div>
   </form>
   <div id="blazar-gantt">

--- a/contrib/horizon/blazardashboard/dashboards/project/leases/templates/leases/calendar.html
+++ b/contrib/horizon/blazardashboard/dashboards/project/leases/templates/leases/calendar.html
@@ -9,16 +9,21 @@
 {% block main %}
   <form class="form-inline" name="blazar-gantt-controls">
     <div class="form-group gantt-group">
+      <button class="btn btn-sm gantt-quickdays" data-gantt-days="1">1d</button>
+      <button class="btn btn-sm gantt-quickdays" data-gantt-days="7">1w</button>
+      <button class="btn btn-sm gantt-quickdays" data-gantt-days="31">1m</button>
+    </div>
+    <div class="form-group gantt-group">
       <label for="dateStart">Start</label>
-      <input class="form-control" type="text" name="dateStart" id="dateStart" style="width:120px" placeholder="MM/DD/YYYY">
-      <input class="form-control" type="number" min="00" max="23" name="timeStartHours" id="timeStartHours" style="width:55px" placeholder="hh">
+      <input class="form-control gantt-datebox-date" type="text" name="dateStart" id="dateStart" placeholder="MM/DD/YYYY">
+      <input class="form-control gantt-datebox-hour" type="number" min="00" max="23" name="timeStartHours" id="timeStartHours" placeholder="hh">
       :
       00
     </div>
     <div class="form-group gantt-group">
       <label for="dateEnd">End</label>
-      <input class="form-control" type="text" name="dateEnd" id="dateEnd" style="width:120px" placeholder="MM/DD/YYYY">
-      <input class="form-control" type="number" min="00" max="23" name="timeEndHours" id="timeEndHours" style="width:55px" placeholder="hh">
+      <input class="form-control gantt-datebox-date" type="text" name="dateEnd" id="dateEnd" placeholder="MM/DD/YYYY">
+      <input class="form-control gantt-datebox-hour" type="number" min="00" max="23" name="timeEndHours" id="timeEndHours" placeholder="hh">
       :
       00
     </div>

--- a/contrib/horizon/blazardashboard/dashboards/project/leases/views.py
+++ b/contrib/horizon/blazardashboard/dashboards/project/leases/views.py
@@ -54,7 +54,7 @@ class CalendarView(views.APIView):
 
 def calendar_data_view(request):
     data = {}
-    data['compute_hosts'] = api.blazar.compute_host_list(request)
+    data['compute_hosts'] = api.blazar.compute_host_list(request, node_types=True)
     data['reservations'] = api.blazar.reservation_calendar(request)
 
     return HttpResponse(json.dumps(data, cls=DjangoJSONEncoder), content_type="application/json")


### PR DESCRIPTION
Scrape out the node types from the extra capabilities table and attach them to the compute node objects already in the `calendar.json` endpoint. Browser scans through them and adds available node types to a dropdown.

Later, when one is selected, it filters the chart's `taskTypes` (`taskNames` is the variable name) and rebuilds the whole thing. The chart doesn't seem to take an updated version of the list like other D3 objects can, or rather, I couldn't figure it out.