### PR TITLE
Explicitly attach blazar to api module

### DIFF
--- a/contrib/horizon/blazardashboard/api/__init__.py
+++ b/contrib/horizon/blazardashboard/api/__init__.py
@@ -1,0 +1,1 @@
+from . import blazar

--- a/contrib/horizon/blazardashboard/api/blazar.py
+++ b/contrib/horizon/blazardashboard/api/blazar.py
@@ -189,8 +189,6 @@ def available_nodetypes():
     WHERE
         capability_name = 'node_type'
         AND deleted = '0'
-    GROUP BY
-        computehost_id
     '''
     cursor.execute(sql)
     available = {row[0] for row in cursor.fetchall()}

--- a/contrib/horizon/blazardashboard/api/blazar.py
+++ b/contrib/horizon/blazardashboard/api/blazar.py
@@ -13,17 +13,35 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from collections import OrderedDict
 import logging
+
+from django.db import connections
+from django.utils.translation import ugettext_lazy as _
+import six
 
 from climateclient import client as blazar_client
 from climateclient import exception as blazar_exception
 
 from openstack_dashboard.api import base
 
-from django.db import connections
 
 LOG = logging.getLogger(__name__)
 LEASE_DATE_FORMAT = "%Y-%m-%d %H:%M"
+
+PRETTY_TYPE_NAMES = OrderedDict([
+    ('compute', _('Compute Node (default)')),
+    ('storage', _('Storage')),
+    ('gpu_k80', _('GPU (K80)')),
+    ('gpu_m40', _('GPU (M40)')),
+    ('gpu_p100', _('GPU (P100)')),
+    ('compute_ib', _('Infiniband Support')),
+    ('storage_hierarchy', _('Storage Hierarchy')),
+    ('fpga', _('FPGA')),
+    ('lowpower_xeon', _('Low power Xeon')),
+    ('atom', _('Atom')),
+    ('arm64', _('ARM64')),
+])
 
 
 class Lease(base.APIDictWrapper):
@@ -160,3 +178,28 @@ def reservation_calendar(request):
     host_reservations = dictfetchall(cursor)
 
     return host_reservations
+
+def available_nodetypes():
+    cursor = connections['blazar'].cursor()
+    sql = '''\
+    SELECT DISTINCT
+        capability_value
+    FROM
+        computehost_extra_capabilities
+    WHERE
+        capability_name = 'node_type'
+        AND deleted = '0'
+    GROUP BY
+        computehost_id
+    '''
+    cursor.execute(sql)
+    available = {row[0] for row in cursor.fetchall()}
+    choices = [(k, six.text_type(v)) for k, v in PRETTY_TYPE_NAMES.items() if k in available]
+
+    unprettyable = available - set(PRETTY_TYPE_NAMES)
+    if unprettyable:
+        unprettyable = sorted(unprettyable)
+        choices.extend((k, k) for k in unprettyable)
+        LOG.debug('New node types without pretty name(s): {}'.format(unprettyable))
+
+    return choices

--- a/contrib/horizon/blazardashboard/dashboards/project/leases/forms.py
+++ b/contrib/horizon/blazardashboard/dashboards/project/leases/forms.py
@@ -104,10 +104,10 @@ class CreateForm(forms.SelfHandlingForm):
     )
     node_type = forms.ChoiceField(
         label=_('Node Type to Reserve'),
-        help_text=_('Choose standard compute nodes or nodes with heterogenous '
-                    'hardware such as more disk, GPUs, multiple storage devices, '
-                    'Infiniband, and more. Different hardware is available in '
-                    'different regions.'),
+        help_text=_('Choose standard compute nodes or heterogenous nodes with '
+                    'either more storage space, varied storage devices, GPUs, '
+                    'Infiniband, or other specialized hardware. Different '
+                    'hardware is available on different sites.'),
         choices=api.blazar.available_nodetypes
     )
 

--- a/contrib/horizon/blazardashboard/dashboards/project/leases/forms.py
+++ b/contrib/horizon/blazardashboard/dashboards/project/leases/forms.py
@@ -104,22 +104,11 @@ class CreateForm(forms.SelfHandlingForm):
     )
     node_type = forms.ChoiceField(
         label=_('Node Type to Reserve'),
-        help_text=_('You can request to reserve nodes with Large Disk, GPU (K80 or M40), Storage '
-                    'Hierarchy, or Infiniband Support, or request standard compute '
-                    'nodes.'),
-        choices=(
-            ('compute', _('Compute Node (default)')),
-            ('storage', _('Storage')),
-            ('gpu_k80', _('GPU (K80)')),
-            ('gpu_m40', _('GPU (M40)')),
-            ('gpu_p100', _('GPU (P100)')),
-            ('compute_ib', _('Infiniband Support')),
-            ('storage_hierarchy', _('Storage Hierarchy')),
-            ('fpga', _('FPGA')),
-            ('lowpower_xeon', _('Low power Xeon')),
-            ('atom', _('Atom')),
-            ('arm64', _('ARM64')),
-        )
+        help_text=_('Choose standard compute nodes or nodes with heterogenous '
+                    'hardware such as more disk, GPUs, multiple storage devices, '
+                    'Infiniband, and more. Different hardware is available in '
+                    'different regions.'),
+        choices=api.blazar.available_nodetypes
     )
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Should eliminate `AttributeError`s if `forms.py` is for some reason getting executed earlier. `forms.py` had (before previous PRs):

```
from blazardashboard import api
```

but everything that uses it is of the form `api.blazar.XXX`, so it relied on *something, somewhere else* to bind the `blazar` name to the `blazardashboard.api` module namespace. Previously, those were all in functions, so it had a good amount of opportunity to let the fix magically happen, but the function I hung on the form was being executed at import-time and trod on that peculiar landmine.

Should be one line fix 🤞 