### PR TITLE
Fix invalid column error message

### DIFF
--- a/blazarclient/command.py
+++ b/blazarclient/command.py
@@ -259,15 +259,14 @@ class ListCommand(BlazarCommand, lister.Lister):
         compares the parsed_args to the list output by this function.
         """
         columns = len(info) > 0 and sorted(info[0].keys()) or []
-        if not columns:
-            parsed_args.columns = []
-        elif parsed_args.columns:
-            valid_parsed_columns = {
-                col for col in parsed_args.columns if col in columns
-            }
-            columns = list(valid_parsed_columns | set(columns))
-        elif self.list_columns:
-            columns = [col for col in self.list_columns if col in columns]
+        if parsed_args.columns:
+            valid_parsed_columns = {col for col in parsed_args.columns if col in columns}
+        else:
+            valid_parsed_columns = set()
+        if self.list_columns:
+            columns = {
+                          col for col in self.list_columns if col in columns
+                      } | valid_parsed_columns
         return (
             columns,
             (utils.get_item_properties(s, columns, formatters=self._formatters)

--- a/blazarclient/command.py
+++ b/blazarclient/command.py
@@ -262,7 +262,10 @@ class ListCommand(BlazarCommand, lister.Lister):
         if not columns:
             parsed_args.columns = []
         elif parsed_args.columns:
-            columns = [col for col in parsed_args.columns if col in columns] + columns
+            valid_parsed_columns = {
+                col for col in parsed_args.columns if col in columns
+            }
+            columns = list(valid_parsed_columns | set(columns))
         elif self.list_columns:
             columns = [col for col in self.list_columns if col in columns]
         return (

--- a/blazarclient/command.py
+++ b/blazarclient/command.py
@@ -252,11 +252,17 @@ class ListCommand(BlazarCommand, lister.Lister):
         return data
 
     def setup_columns(self, info, parsed_args):
+        """
+        Determines the list of columns that may be visible to the client. This may not
+        be the columns that are actually visible to the client on the output of their
+        command. The output columns are determined by a process in cliff.display which
+        compares the parsed_args to the list output by this function.
+        """
         columns = len(info) > 0 and sorted(info[0].keys()) or []
         if not columns:
             parsed_args.columns = []
         elif parsed_args.columns:
-            columns = [col for col in parsed_args.columns if col in columns]
+            columns = [col for col in parsed_args.columns if col in columns] + columns
         elif self.list_columns:
             columns = [col for col in self.list_columns if col in columns]
         return (


### PR DESCRIPTION
This bug occurred when a user passed only invalid column names to the client via a list-* command. Column names are intended to be processed by the `cliff` library, which compares the base columns which may be viewed by the user against any columns they may have included in their arguments. There is an unnecessary processing step in the `setup_columns` method which removes any invalid columns input by the user from the base list. That means that if only invalid columns are included, `cliff` receives an empty list of possible columns, which it treats as the only invalid configuration. Otherwise, it will simply ignore any invalid columns in the args provided by the user.

This patch fixes the pre-processing step in `setup_columns` by ensuring that the base columns visible via the command will always be passed to cliff. The reason why this step was not eliminated entirely was to retain the previous behavior of the Blazar client where a user may "look ahead" at columns added to the Blazar API which are not yet supported by their client by simply passing them to the command with `-c`.
