### PR TITLE
Allow host lookup by UUID, Int ID, and Hypervisor Hostname

### DIFF
--- a/blazarclient/v1/shell_commands/hosts.py
+++ b/blazarclient/v1/shell_commands/hosts.py
@@ -18,7 +18,8 @@ import logging
 from blazarclient import command
 from blazarclient import exception
 
-HOST_ID_PATTERN = '^[0-9]+$'
+# Matches integers or UUIDs
+HOST_ID_PATTERN = r'^([0-9]+|([0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}))$'
 
 
 class ListHosts(command.ListCommand):


### PR DESCRIPTION
This change allows hosts to be looked up by any of these three properties:

* Legacy integer IDs
* UUIDs
* Hypervisor Hostnames, which are considered to be resource names, and which are also UUIDs
