### PR TITLE
sort network-list on segment_id by default

### DIFF
--- a/blazarclient/tests/v1/shell_commands/test_floatingips.py
+++ b/blazarclient/tests/v1/shell_commands/test_floatingips.py
@@ -71,7 +71,8 @@ class ListFloatingIPsTest(tests.TestCase):
                              ('f180cf4c-f886-4dd1-8c36-854d17fbefb5',)]]
 
         ret = list_floatingips.get_data(args)
-        self.assertEqual(expected[0], ret[0])
+        # ret is a set
+        self.assertEqual(expected[0], list(ret[0]))
         self.assertEqual(expected[1], [x for x in ret[1]])
 
         floatingip_manager.list.assert_called_once_with(sort_by='id')

--- a/blazarclient/tests/v1/shell_commands/test_leases.py
+++ b/blazarclient/tests/v1/shell_commands/test_leases.py
@@ -328,6 +328,10 @@ class ShowLeaseTestCase(tests.TestCase):
     def test_show_lease(self):
         show_lease, lease_manager = self.create_show_command()
         lease_manager.get.return_value = {'id': FIRST_LEASE}
+        lease_manager.list.return_value = [
+            {'id': FIRST_LEASE, 'name': 'first-lease'},
+            {'id': SECOND_LEASE, 'name': 'second-lease'},
+        ]
         mock.seal(lease_manager)
 
         args = argparse.Namespace(id=FIRST_LEASE)
@@ -368,6 +372,7 @@ class DeleteLeaseTestCase(tests.TestCase):
     def test_delete_lease(self):
         delete_lease, lease_manager = self.create_delete_command()
         lease_manager.delete.return_value = None
+        lease_manager.list.return_value = [{'id': FIRST_LEASE}]
         mock.seal(lease_manager)
 
         args = argparse.Namespace(id=FIRST_LEASE)

--- a/blazarclient/tests/v1/shell_commands/test_networks.py
+++ b/blazarclient/tests/v1/shell_commands/test_networks.py
@@ -103,20 +103,20 @@ class UnsetAttributesNetworkTest(tests.TestCase):
 
     def test_unset_network(self):
         list_value = [
-            {'id': '101', 'networkname': 'network-1'},
-            {'id': '201', 'networkname': 'network-2'},
+            {'id': '072c58c0-64ac-467b-b040-9138771e146a', 'networkname': 'network-1'},
+            {'id': '072c58c0-64ac-467b-b040-9138771e146b', 'networkname': 'network-2'},
         ]
         unset_network, network_manager = self.create_unset_command(list_value)
         extra_caps = ['key1', 'key2']
         args = argparse.Namespace(
-            id='101',
+            id='072c58c0-64ac-467b-b040-9138771e146a',
             extra_capabilities=extra_caps,
         )
         expected = {
             'values': {key: None for key in extra_caps}
        }
         unset_network.run(args)
-        network_manager.assert_called_once_with('101', **expected)
+        network_manager.update.assert_called_once_with('072c58c0-64ac-467b-b040-9138771e146a', **expected)
 
 class ShowNetworkTest(tests.TestCase):
 
@@ -231,11 +231,11 @@ class ListNetworksTest(tests.TestCase):
 
         list_network, network_manager = self.create_list_command()
         list_networks_args = argparse.Namespace(
-            columns=['segment_id', 'id']
+            sort_by='segment_id',
+            columns=[]
         )
         return_networks = list_network.get_data(list_networks_args)
         segment_id_index = list(return_networks[0]).index('segment_id')
-        print(segment_id_index)
         prev_segment_id = 0
         for network in list(return_networks[1]):
             network_segment_id = network[segment_id_index]

--- a/blazarclient/tests/v1/shell_commands/test_networks.py
+++ b/blazarclient/tests/v1/shell_commands/test_networks.py
@@ -14,10 +14,11 @@
 # limitations under the License.
 
 import argparse
-import mock
+from unittest import mock
 
 from blazarclient import shell
 from blazarclient import tests
+from blazarclient.v1.networks import NetworkClientManager
 from blazarclient.v1.shell_commands import networks
 
 
@@ -65,12 +66,12 @@ class UpdateNetworkTest(tests.TestCase):
 
     def test_update_network(self):
         list_value = [
-            {'id': '101', 'networkname': 'network-1'},
-            {'id': '201', 'networkname': 'network-2'},
+            {'id': '072c58c0-64ac-467b-b040-9138771e146a', 'networkname': 'network-1'},
+            {'id': '072c58c0-64ac-467b-b040-9138771e146a', 'networkname': 'network-2'},
         ]
         update_network, network_manager = self.create_update_command(list_value)
         args = argparse.Namespace(
-            id='101',
+            id='072c58c0-64ac-467b-b040-9138771e146a',
             extra_capabilities=[
                 'key1=value1',
                 'key2=value2'
@@ -82,7 +83,7 @@ class UpdateNetworkTest(tests.TestCase):
             }
         }
         update_network.run(args)
-        network_manager.update.assert_called_once_with('101', **expected)
+        network_manager.update.assert_called_once_with('072c58c0-64ac-467b-b040-9138771e146a', **expected)
 
 
 class UnsetAttributesNetworkTest(tests.TestCase):
@@ -133,22 +134,22 @@ class ShowNetworkTest(tests.TestCase):
 
     def test_show_network(self):
         list_value = [
-            {'id': '101'},
-            {'id': '201'},
+            {'id': '072c58c0-64ac-467b-b040-9138771e146a'},
+            {'id': '072c58c0-64ac-467b-b040-9138771e146b'},
         ]
         get_value = {
-            'id': '101'}
+            'id': '072c58c0-64ac-467b-b040-9138771e146a'}
 
         show_network, network_manager = self.create_show_command(list_value,
                                                            get_value)
 
-        args = argparse.Namespace(id='101')
-        expected = [('id',), ('101',)]
+        args = argparse.Namespace(id='072c58c0-64ac-467b-b040-9138771e146a')
+        expected = [('id',), ('072c58c0-64ac-467b-b040-9138771e146a',)]
 
         ret = show_network.get_data(args)
         self.assertEqual(ret, expected)
 
-        network_manager.get.assert_called_once_with('101')
+        network_manager.get.assert_called_once_with('072c58c0-64ac-467b-b040-9138771e146a')
 
 
 class DeleteNetworkTest(tests.TestCase):
@@ -165,13 +166,79 @@ class DeleteNetworkTest(tests.TestCase):
         return networks.DeleteNetwork(blazar_shell, mock.Mock()), mock_network_manager
 
     def test_delete_network(self):
+        # ID should be of format of blazarclient.command.UUID_PATTERN
         list_value = [
-            {'id': '101', 'networkname': 'network-1'},
-            {'id': '201', 'networkname': 'network-2'},
+            {'id': '072c58c0-64ac-467b-b040-9138771e146a', 'networkname': 'network-1'},
+            {'id': '072c58c0-64ac-467b-b040-9138771e146b', 'networkname': 'network-2'},
         ]
         delete_network, network_manager = self.create_delete_command(list_value)
 
-        args = argparse.Namespace(id='101')
+        args = argparse.Namespace(id='072c58c0-64ac-467b-b040-9138771e146a')
         delete_network.run(args)
 
-        network_manager.delete.assert_called_once_with('101')
+        network_manager.delete.assert_called_once_with('072c58c0-64ac-467b-b040-9138771e146a')
+
+class MockNetworkClientManager(NetworkClientManager):
+    def __init__(self):
+        self.request_manager = MockRequestManager()
+
+class MockRequestManager:
+    def get(self, url):
+        return "-", {
+            "networks":
+            [
+                {
+                    "id": "256c0f35-b29e-45cb-9931-ea785f415955",
+                    "network_type": "vlan",
+                    "physical_network": "physnet1",
+                    "segment_id": 3008
+                },
+                {
+                    "id": "937ad993-53c6-4055-9802-e8f360f46598",
+                    "network_type": "vlan",
+                    "physical_network": "physnet1",
+                    "segment_id": 3294
+                },
+                {
+                    "id": "d97e5bb4-46e2-4b65-a460-a2d0bb305d29",
+                    "network_type": "vlan",
+                    "physical_network": "physnet1",
+                    "segment_id": 3006
+                },
+                {
+                    "id": "ee5ec1b8-7295-4c56-8f85-4c89317785d9",
+                    "network_type": "vlan",
+                    "physical_network": "physnet1",
+                    "segment_id": 3009
+                }
+            ]
+        }
+
+
+class ListNetworksTest(tests.TestCase):
+
+    def create_list_command(self):
+        mock_network_manager = MockNetworkClientManager()
+
+        mock_client = mock.Mock()
+        mock_client.network = mock_network_manager
+
+        blazar_shell = shell.BlazarShell()
+        blazar_shell.client = mock_client
+        return networks.ListNetworks(blazar_shell, mock.Mock()), mock_network_manager
+
+    def test_list_network_sort_by(self):
+
+        list_network, network_manager = self.create_list_command()
+        list_networks_args = argparse.Namespace(
+            columns=['segment_id', 'id']
+        )
+        return_networks = list_network.get_data(list_networks_args)
+        segment_id_index = list(return_networks[0]).index('segment_id')
+        print(segment_id_index)
+        prev_segment_id = 0
+        for network in list(return_networks[1]):
+            network_segment_id = network[segment_id_index]
+            self.assertLess(prev_segment_id, network_segment_id)
+            prev_segment_id = network_segment_id
+        # network_manager.list.assert_called_once_with(sort_by='segment_id')

--- a/blazarclient/v1/shell_commands/networks.py
+++ b/blazarclient/v1/shell_commands/networks.py
@@ -30,7 +30,7 @@ class ListNetworks(command.ListCommand):
         parser.add_argument(
             '--sort-by', metavar="<network_column>",
             help='column name used to sort result',
-            default='id'
+            default='segment_id'
         )
         return parser
 
@@ -219,7 +219,6 @@ class ListNetworkCapabilities(command.ListCommand):
             else:
                 msg = 'Invalid sort option %s' % parsed_args.sort_by
                 raise exception.BlazarClientException(msg)
-
         return params
 
     def retrieve_list(self, parsed_args):


### PR DESCRIPTION
- Changed the default value of sort_by argument to use segment_id
- Added a new test case to check the sorted values
- Fixed other failing testcases