### PR TITLE
Fix network-list not showing the column when all of them not have it

### DIFF
--- a/blazarclient/command.py
+++ b/blazarclient/command.py
@@ -260,7 +260,11 @@ class ListCommand(BlazarCommand, lister.Lister):
         command. The output columns are determined by a process in cliff.display which
         compares the parsed_args to the list output by this function.
         """
-        columns = len(info) > 0 and sorted(info[0].keys()) or []
+        # return empty list when info is empty
+        # or sort all keys that are in all the networks
+        columns = (
+            len(info) > 0 and sorted({k for d in info for k in d.keys()}) or []
+        )
         if parsed_args.columns:
             valid_parsed_columns = {col for col in parsed_args.columns if col in columns}
         else:

--- a/blazarclient/utils.py
+++ b/blazarclient/utils.py
@@ -93,8 +93,8 @@ def get_item_properties(item, fields, mixed_case_fields=None, formatters=None):
             else:
                 field_name = field.lower().replace(' ', '_')
             if not hasattr(item, field_name) and isinstance(item, dict):
-                # display null if the resource does not have a field
-                data = item.get(field_name, "null")
+                # display empty string if the resource does not have a field
+                data = item.get(field_name, '')
             else:
                 data = getattr(item, field_name, '')
             if data is None:

--- a/blazarclient/utils.py
+++ b/blazarclient/utils.py
@@ -93,7 +93,8 @@ def get_item_properties(item, fields, mixed_case_fields=None, formatters=None):
             else:
                 field_name = field.lower().replace(' ', '_')
             if not hasattr(item, field_name) and isinstance(item, dict):
-                data = item[field_name]
+                # display null if the resource does not have a field
+                data = item.get(field_name, "null")
             else:
                 data = getattr(item, field_name, '')
             if data is None:


### PR DESCRIPTION
Display "null" if a network does not have the specified column in args

Redmine ticket: 23648

` ➜  python-blazarclient git:(network-list-columns-bug-fix) ✗ blazar network-list -c id -c usage_type`
``` 
+------------+--------------------------------------+
| usage_type | id                                   |
+------------+--------------------------------------+
|            | d97e5bb4-46e2-4b65-a460-a2d0bb305d29 |
| storage    | e7fddbf5-04ed-461b-b0fa-d84d859d3507 |
| storage    | 256c0f35-b29e-45cb-9931-ea785f415955 |
|            | ee5ec1b8-7295-4c56-8f85-4c89317785d9 |
|            | 937ad993-53c6-4055-9802-e8f360f46598 |
+------------+--------------------------------------+