### PR TITLE
Flake8 fixes - inline with upstream

### DIFF
--- a/blazarclient/command.py
+++ b/blazarclient/command.py
@@ -254,11 +254,11 @@ class ListCommand(BlazarCommand, lister.Lister):
         return data
 
     def setup_columns(self, info, parsed_args):
-        """
-        Determines the list of columns that may be visible to the client. This may not
-        be the columns that are actually visible to the client on the output of their
-        command. The output columns are determined by a process in cliff.display which
-        compares the parsed_args to the list output by this function.
+        """Determines the list of columns that may be visible to the client.
+        This may not be the columns that are actually visible to the client
+        on the output of their command. The output columns are determined
+        by a process in cliff.display which compares the parsed_args to the
+        list output by this function.
         """
         # return empty list when info is empty
         # or sort all keys that are in all the networks
@@ -266,13 +266,15 @@ class ListCommand(BlazarCommand, lister.Lister):
             len(info) > 0 and sorted({k for d in info for k in d.keys()}) or []
         )
         if parsed_args.columns:
-            valid_parsed_columns = {col for col in parsed_args.columns if col in columns}
+            valid_parsed_columns = {
+                col for col in parsed_args.columns if col in columns
+            }
         else:
             valid_parsed_columns = set()
         if self.list_columns:
             columns = {
-                          col for col in self.list_columns if col in columns
-                      } | valid_parsed_columns
+                col for col in self.list_columns if col in columns
+            } | valid_parsed_columns
         return (
             columns,
             (utils.get_item_properties(s, columns, formatters=self._formatters)

--- a/blazarclient/shell.py
+++ b/blazarclient/shell.py
@@ -354,7 +354,8 @@ class BlazarShell(app.App):
         self.client = blazar_client.Client(
             self.options.os_reservation_api_version,
             session=sess,
-            service_type=self.options.service_type or self.options.os_service_type,
+            service_type=(self.options.service_type or
+                          self.options.os_service_type),
             interface=self.options.endpoint_type or self.options.os_interface,
             region_name=self.options.os_region_name,
         )

--- a/blazarclient/tests/v1/shell_commands/test_networks.py
+++ b/blazarclient/tests/v1/shell_commands/test_networks.py
@@ -26,7 +26,9 @@ class CreateNetworkTest(tests.TestCase):
 
     def setUp(self):
         super(CreateNetworkTest, self).setUp()
-        self.create_network = networks.CreateNetwork(shell.BlazarShell(), mock.Mock())
+        self.create_network = networks.CreateNetwork(
+            shell.BlazarShell(), mock.Mock()
+        )
 
     def test_args2body(self):
         args = argparse.Namespace(
@@ -62,14 +64,24 @@ class UpdateNetworkTest(tests.TestCase):
 
         blazar_shell = shell.BlazarShell()
         blazar_shell.client = mock_client
-        return networks.UpdateNetwork(blazar_shell, mock.Mock()), mock_network_manager
+        return networks.UpdateNetwork(
+            blazar_shell, mock.Mock()
+        ), mock_network_manager
 
     def test_update_network(self):
         list_value = [
-            {'id': '072c58c0-64ac-467b-b040-9138771e146a', 'networkname': 'network-1'},
-            {'id': '072c58c0-64ac-467b-b040-9138771e146a', 'networkname': 'network-2'},
+            {
+                'id': '072c58c0-64ac-467b-b040-9138771e146a',
+                'networkname': 'network-1'
+            },
+            {
+                'id': '072c58c0-64ac-467b-b040-9138771e146a',
+                'networkname': 'network-2'
+            },
         ]
-        update_network, network_manager = self.create_update_command(list_value)
+        update_network, network_manager = self.create_update_command(
+            list_value
+        )
         args = argparse.Namespace(
             id='072c58c0-64ac-467b-b040-9138771e146a',
             extra_capabilities=[
@@ -83,7 +95,9 @@ class UpdateNetworkTest(tests.TestCase):
             }
         }
         update_network.run(args)
-        network_manager.update.assert_called_once_with('072c58c0-64ac-467b-b040-9138771e146a', **expected)
+        network_manager.update.assert_called_once_with(
+            '072c58c0-64ac-467b-b040-9138771e146a', **expected
+        )
 
 
 class UnsetAttributesNetworkTest(tests.TestCase):
@@ -103,8 +117,14 @@ class UnsetAttributesNetworkTest(tests.TestCase):
 
     def test_unset_network(self):
         list_value = [
-            {'id': '072c58c0-64ac-467b-b040-9138771e146a', 'networkname': 'network-1'},
-            {'id': '072c58c0-64ac-467b-b040-9138771e146b', 'networkname': 'network-2'},
+            {
+                'id': '072c58c0-64ac-467b-b040-9138771e146a',
+                'networkname': 'network-1'
+            },
+            {
+                'id': '072c58c0-64ac-467b-b040-9138771e146b',
+                'networkname': 'network-2'
+            },
         ]
         unset_network, network_manager = self.create_unset_command(list_value)
         extra_caps = ['key1', 'key2']
@@ -114,12 +134,14 @@ class UnsetAttributesNetworkTest(tests.TestCase):
         )
         expected = {
             'values': {key: None for key in extra_caps}
-       }
+        }
         unset_network.run(args)
-        network_manager.update.assert_called_once_with('072c58c0-64ac-467b-b040-9138771e146a', **expected)
+        network_manager.update.assert_called_once_with(
+            '072c58c0-64ac-467b-b040-9138771e146a', **expected
+        )
+
 
 class ShowNetworkTest(tests.TestCase):
-
     def create_show_command(self, list_value, get_value):
         mock_network_manager = mock.Mock()
         mock_network_manager.list.return_value = list_value
@@ -130,7 +152,9 @@ class ShowNetworkTest(tests.TestCase):
 
         blazar_shell = shell.BlazarShell()
         blazar_shell.client = mock_client
-        return networks.ShowNetwork(blazar_shell, mock.Mock()), mock_network_manager
+        return networks.ShowNetwork(
+            blazar_shell, mock.Mock()
+        ), mock_network_manager
 
     def test_show_network(self):
         list_value = [
@@ -140,8 +164,9 @@ class ShowNetworkTest(tests.TestCase):
         get_value = {
             'id': '072c58c0-64ac-467b-b040-9138771e146a'}
 
-        show_network, network_manager = self.create_show_command(list_value,
-                                                           get_value)
+        show_network, network_manager = self.create_show_command(
+            list_value, get_value
+        )
 
         args = argparse.Namespace(id='072c58c0-64ac-467b-b040-9138771e146a')
         expected = [('id',), ('072c58c0-64ac-467b-b040-9138771e146a',)]
@@ -149,7 +174,9 @@ class ShowNetworkTest(tests.TestCase):
         ret = show_network.get_data(args)
         self.assertEqual(ret, expected)
 
-        network_manager.get.assert_called_once_with('072c58c0-64ac-467b-b040-9138771e146a')
+        network_manager.get.assert_called_once_with(
+            '072c58c0-64ac-467b-b040-9138771e146a'
+        )
 
 
 class DeleteNetworkTest(tests.TestCase):
@@ -163,24 +190,37 @@ class DeleteNetworkTest(tests.TestCase):
 
         blazar_shell = shell.BlazarShell()
         blazar_shell.client = mock_client
-        return networks.DeleteNetwork(blazar_shell, mock.Mock()), mock_network_manager
+        return networks.DeleteNetwork(
+            blazar_shell, mock.Mock()
+        ), mock_network_manager
 
     def test_delete_network(self):
         # ID should be of format of blazarclient.command.UUID_PATTERN
         list_value = [
-            {'id': '072c58c0-64ac-467b-b040-9138771e146a', 'networkname': 'network-1'},
-            {'id': '072c58c0-64ac-467b-b040-9138771e146b', 'networkname': 'network-2'},
+            {
+                'id': '072c58c0-64ac-467b-b040-9138771e146a',
+                'networkname': 'network-1'},
+            {
+                'id': '072c58c0-64ac-467b-b040-9138771e146b',
+                'networkname': 'network-2'
+            },
         ]
-        delete_network, network_manager = self.create_delete_command(list_value)
+        delete_network, network_manager = self.create_delete_command(
+            list_value
+        )
 
         args = argparse.Namespace(id='072c58c0-64ac-467b-b040-9138771e146a')
         delete_network.run(args)
 
-        network_manager.delete.assert_called_once_with('072c58c0-64ac-467b-b040-9138771e146a')
+        network_manager.delete.assert_called_once_with(
+            '072c58c0-64ac-467b-b040-9138771e146a'
+        )
+
 
 class MockNetworkClientManager(NetworkClientManager):
     def __init__(self):
         self.request_manager = MockRequestManager()
+
 
 class MockRequestManager:
     def get(self, url):
@@ -216,7 +256,6 @@ class MockRequestManager:
 
 
 class ListNetworksTest(tests.TestCase):
-
     def create_list_command(self):
         mock_network_manager = MockNetworkClientManager()
 
@@ -225,7 +264,9 @@ class ListNetworksTest(tests.TestCase):
 
         blazar_shell = shell.BlazarShell()
         blazar_shell.client = mock_client
-        return networks.ListNetworks(blazar_shell, mock.Mock()), mock_network_manager
+        return networks.ListNetworks(
+            blazar_shell, mock.Mock()
+        ), mock_network_manager
 
     def test_list_network_sort_by(self):
 
@@ -241,4 +282,3 @@ class ListNetworksTest(tests.TestCase):
             network_segment_id = network[segment_id_index]
             self.assertLess(prev_segment_id, network_segment_id)
             prev_segment_id = network_segment_id
-        # network_manager.list.assert_called_once_with(sort_by='segment_id')

--- a/blazarclient/v1/client.py
+++ b/blazarclient/v1/client.py
@@ -65,11 +65,11 @@ class Client(object):
             version=self.version,
             **kwargs)
         self.network = networks.NetworkClientManager(
-                blazar_url=self.blazar_url,
-                auth_token=self.auth_token,
-                session=self.session,
-                version=self.version,
-                **kwargs)
+            blazar_url=self.blazar_url,
+            auth_token=self.auth_token,
+            session=self.session,
+            version=self.version,
+            **kwargs)
         self.device = devices.DeviceClientManager(
             blazar_url=self.blazar_url,
             auth_token=self.auth_token,

--- a/blazarclient/v1/shell_commands/devices.py
+++ b/blazarclient/v1/shell_commands/devices.py
@@ -141,7 +141,8 @@ class UnsetAttributeDevice(UpdateDevice):
             action='append',
             dest='extra_capabilities',
             default=[],
-            help='Extra capability keys which should be unset from the device.',
+            help='Extra capability keys which should be unset'
+            'from the device.',
         )
         return parser
 

--- a/blazarclient/v1/shell_commands/hosts.py
+++ b/blazarclient/v1/shell_commands/hosts.py
@@ -19,7 +19,10 @@ from blazarclient import command
 from blazarclient import exception
 
 # Matches integers or UUIDs
-HOST_ID_PATTERN = r'^([0-9]+|([0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}))$'
+HOST_ID_PATTERN = (
+    r"^([0-9]+|([0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]"
+    r"{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}))$"
+)
 
 
 class ListHosts(command.ListCommand):
@@ -140,6 +143,7 @@ class UnsetAttributesHost(UpdateHost):
             }
         else:
             return {}
+
 
 class DeleteHost(command.DeleteCommand):
     """Delete a host."""

--- a/blazarclient/v1/shell_commands/networks.py
+++ b/blazarclient/v1/shell_commands/networks.py
@@ -53,8 +53,8 @@ class CreateNetwork(command.CreateCommand):
         parser.add_argument(
             '--network-type',
             help='Type of physical mechanism associated with the network '
-                  'segment. For example: flat, geneve, gre, local, vlan, '
-                  'vxlan.'
+            'segment. For example: flat, geneve, gre, local, vlan, '
+            'vxlan.'
         )
         parser.add_argument(
             '--physical-network',
@@ -142,6 +142,7 @@ class UpdateNetwork(command.UpdateCommand):
             params['values'] = extras
         return params
 
+
 class UnsetAttributeNetwork(UpdateNetwork):
     log = logging.getLogger(__name__ + '.UnsetAttributeNetwork')
 
@@ -152,7 +153,8 @@ class UnsetAttributeNetwork(UpdateNetwork):
             action='append',
             dest='extra_capabilities',
             default=[],
-            help='Extra capability keys which should be unset from the network.'
+            help='Extra capability keys which should be unset'
+            'from the network.'
         )
         return parser
 


### PR DESCRIPTION
All the changes are in line with upstream - all the code with formatting issues are in our repo and are our changes

too long lines command.py, over-indent in client.py

long line and blank lines expected in hosts.py

Long line fix in shell.py

Too many long lines and formatting fixes in test_networks.py - this is not in upstream