### PR TITLE
Add support for setting capability uniqueness in blazar client

### DIFF
--- a/blazarclient/command.py
+++ b/blazarclient/command.py
@@ -441,9 +441,16 @@ class UpdateCapabilityCommand(BlazarCommand):
             default=False,
             help='Set capability to public.'
         )
+        parser.add_argument(
+            '--unique',
+            action='store_true',
+            default=False,
+            help='Set capability as unique.'
+        )
         return parser
 
     def args2body(self, parsed_args):
         return dict(
             capability_name=parsed_args.capability_name,
-            private=(parsed_args.private is True))
+            private=(parsed_args.private is True),
+            is_unique=(parsed_args.unique is True))

--- a/blazarclient/v1/hosts.py
+++ b/blazarclient/v1/hosts.py
@@ -100,8 +100,8 @@ class ComputeHostClientManager(base.BaseClientManager):
 
         return {} if not resource_property else resource_property[0]
 
-    def set_capability(self, capability_name, private):
-        data = {'private': private}
+    def set_capability(self, capability_name, private, is_unique=False):
+        data = {'private': private, 'is_unique': is_unique}
         resp, body = self.request_manager.patch(
             '/os-hosts/properties/%s' % capability_name, body=data)
 

--- a/blazarclient/v1/shell_commands/hosts.py
+++ b/blazarclient/v1/shell_commands/hosts.py
@@ -213,7 +213,7 @@ class ListHostCapabilities(command.ListCommand):
     """List host capabilities."""
     resource = 'host'
     log = logging.getLogger(__name__ + '.ListHostCapabilities')
-    list_columns = ['property', 'private', 'capability_values']
+    list_columns = ['property', 'private', 'capability_values', 'is_unique']
 
     def args2body(self, parsed_args):
         params = {'detail': parsed_args.detail}


### PR DESCRIPTION
Updated the `UpdateCapabilityCommand` in the blazar client to include a new `--unique` flag, allowing users to set a capability as unique when updating or creating a capability. Also, modified the `set_capability` method in the `ComputeHostClientManager` to include the `is_unique` parameter when sending a PATCH request to update the capability.

This enhancement enables users to specify whether a capability should be unique or not via the blazar client.

Blazar PR - https://github.com/ChameleonCloud/blazar/pull/111