### PR TITLE
Fix DeviceShow and NetworkShow commands

### DIFF
--- a/blazarclient/utils.py
+++ b/blazarclient/utils.py
@@ -125,9 +125,8 @@ def _find_resource_id_by_name(client, resource_type, name, name_key):
 
     named_resources = []
     key = name_key if name_key else 'name'
-
     for resource in resources:
-        if resource.get(key) == name:
+        if str(resource.get(key)) == name:
             named_resources.append(resource['id'])
     if len(named_resources) > 1:
         raise exception.NoUniqueMatch(message="There are more than one "

--- a/blazarclient/v1/shell_commands/devices.py
+++ b/blazarclient/v1/shell_commands/devices.py
@@ -41,6 +41,16 @@ class ShowDevice(command.ShowCommand):
     name_key = 'name'
     log = logging.getLogger(__name__ + '.ShowDevice')
 
+    def get_parser(self, prog_name):
+        parser = super(ShowDevice, self).get_parser(prog_name)
+        if self.allow_names:
+            help_str = 'Name or ID of %s to look up'
+        else:
+            help_str = 'ID of %s to look up'
+        parser.add_argument('id', metavar=self.resource.upper(),
+                            help=help_str % self.resource)
+        return parser
+
 
 class CreateDevice(command.CreateCommand):
     """Create a device."""

--- a/blazarclient/v1/shell_commands/networks.py
+++ b/blazarclient/v1/shell_commands/networks.py
@@ -39,7 +39,18 @@ class ShowNetwork(command.ShowCommand):
     """Show network details."""
     resource = 'network'
     json_indent = 4
+    name_key = 'segment_id'
     log = logging.getLogger(__name__ + '.ShowNetwork')
+
+    def get_parser(self, prog_name):
+        parser = super(ShowNetwork, self).get_parser(prog_name)
+        if self.allow_names:
+            help_str = 'Segment ID or ID of %s to look up'
+        else:
+            help_str = 'ID of %s to look up'
+        parser.add_argument('id', metavar=self.resource.upper(),
+                            help=help_str % self.resource)
+        return parser
 
 
 class CreateNetwork(command.CreateCommand):


### PR DESCRIPTION
Since commit 6c0ae07ee2426115fb080a32e2f8409e75d46375, the show command parser moved away from the base class, and so we need to implement it in our custom resource types Network and Device. This also casts the field we are comparing to string so that segment id lookup will work.