### PR TITLE
Bugfix/cliffjson

### DIFF
--- a/blazarclient/command.py
+++ b/blazarclient/command.py
@@ -92,30 +92,6 @@ class BlazarCommand(OpenStackCommand):
         parser = super(BlazarCommand, self).get_parser(prog_name)
         return parser
 
-    def format_output_data(self, data):
-        for k, v in data.items():
-            if isinstance(v, str):
-                try:
-                    # Deserialize if possible into dict, lists, tuples...
-                    v = ast.literal_eval(v)
-                except SyntaxError:
-                    # NOTE(sbauza): This is probably a datetime string, we need
-                    #               to keep it unchanged.
-                    pass
-                except ValueError:
-                    # NOTE(sbauza): This is not something AST can evaluate,
-                    #               probably a string.
-                    pass
-            if isinstance(v, list):
-                value = '\n'.join(utils.dumps(
-                    i, indent=self.json_indent) if isinstance(i, dict)
-                    else str(i) for i in v)
-                data[k] = value
-            elif isinstance(v, dict):
-                value = utils.dumps(v, indent=self.json_indent)
-                data[k] = value
-            elif v is None:
-                data[k] = ''
 
     def add_known_arguments(self, parser):
         pass
@@ -137,7 +113,6 @@ class CreateCommand(BlazarCommand, show.ShowOne):
         body = self.args2body(parsed_args)
         resource_manager = getattr(blazar_client, self.resource)
         data = resource_manager.create(**body)
-        self.format_output_data(data)
 
         if data:
             print('Created a new %s:' % self.resource, file=self.app.stdout)
@@ -323,7 +298,6 @@ class ShowCommand(BlazarCommand, show.ShowOne):
 
         resource_manager = getattr(blazar_client, self.resource)
         data = resource_manager.get(res_id)
-        self.format_output_data(data)
         return list(zip(*sorted(data.items())))
 
 
@@ -346,7 +320,6 @@ class ShowAllocationCommand(ShowCommand, show.ShowOne):
         blazar_client = self.get_client()
         resource_manager = getattr(blazar_client, self.resource)
         data = resource_manager.get_allocation(parsed_args.id)
-        self.format_output_data(data)
         return list(zip(*sorted(data.items())))
 
 
@@ -407,8 +380,6 @@ class ShowPropertyCommand(BlazarCommand, show.ShowOne):
         blazar_client = self.get_client()
         resource_manager = getattr(blazar_client, self.resource)
         data = resource_manager.get_property(parsed_args.property_name)
-        if parsed_args.formatter == 'table':
-            self.format_output_data(data)
         return list(zip(*sorted(data.items())))
 
 

--- a/blazarclient/tests/test_command.py
+++ b/blazarclient/tests/test_command.py
@@ -77,20 +77,6 @@ class BlazarCommandTestCase(tests.TestCase):
         self.command.get_parser('TestCase')
         self.parser.assert_called_once_with('TestCase')
 
-    def test_format_output_data(self):
-        data_before = {'key_string': 'string_value',
-                       'key_dict': {'key': 'value'},
-                       'key_list': ['1', '2', '3'],
-                       'key_none': None}
-        data_after = {'key_string': 'string_value',
-                      'key_dict': '{"key": "value"}',
-                      'key_list': '1\n2\n3',
-                      'key_none': ''}
-
-        self.command.format_output_data(data_before)
-
-        self.assertEqual(data_after, data_before)
-
 
 class CreateCommandTestCase(tests.TestCase):
     def setUp(self):

--- a/blazarclient/v1/hosts.py
+++ b/blazarclient/v1/hosts.py
@@ -63,10 +63,7 @@ class ComputeHostClientManager(base.BaseClientManager):
     def list_allocations(self, sort_by=None):
         """List allocations for all hosts."""
         resp, body = self.request_manager.get('/os-hosts/allocations')
-        allocations = body['allocations']
-        if sort_by:
-            allocations = sorted(allocations, key=lambda l: l[sort_by])
-        return allocations
+        return body['allocations']
 
     def reallocate(self, host_id, values):
         """Reallocate host from leases."""

--- a/blazarclient/v1/shell_commands/allocations.py
+++ b/blazarclient/v1/shell_commands/allocations.py
@@ -83,7 +83,6 @@ class ShowAllocations(command.ShowCommand):
                 filter(lambda d: d['id'] == parsed_args.reservation_id,
                        data['reservations']))
 
-        self.format_output_data(data)
         return list(zip(*sorted(data.items())))
 
     def args2body(self, parsed_args):

--- a/blazarclient/v1/shell_commands/hosts.py
+++ b/blazarclient/v1/shell_commands/hosts.py
@@ -15,12 +15,23 @@
 
 import logging
 
-from blazarclient import command
-from blazarclient import exception
+from osc_lib.cli import format_columns
+from osc_lib.command.command import Lister as osc_Lister
+from osc_lib import utils as oscutils
+
+from blazarclient import command, exception
 
 # Matches integers or UUIDs
 HOST_ID_PATTERN = r'^([0-9]+|([0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}))$'
 
+
+_formatters = {
+    "reservations": format_columns.ListDictColumn,
+}
+
+class ALLOCATION_RESOURCE:
+    fields = ["resource_id", "reservations"]
+    labels = ["resource_id", "reservations"]
 
 class ListHosts(command.ListCommand):
     """Print a list of hosts."""
@@ -168,20 +179,43 @@ class ShowHostAllocation(command.ShowAllocationCommand):
     log = logging.getLogger(__name__ + '.ShowHostAllocation')
 
 
-class ListHostAllocations(command.ListAllocationCommand):
+class ListHostAllocations(osc_Lister):
     """List host allocations."""
-    resource = 'host'
     log = logging.getLogger(__name__ + '.ListHostAllocations')
-    list_columns = ['resource_id', 'reservations']
 
     def get_parser(self, prog_name):
         parser = super(ListHostAllocations, self).get_parser(prog_name)
         parser.add_argument(
-            '--sort-by', metavar="<host_column>",
-            help='column name used to sort result',
-            default='resource_id'
+            "--sort-by",
+            metavar="<allocation_column>",
+            help="column name used to sort result",
+            default="resource_id",
         )
         return parser
+    
+    def take_action(self, parsed_args):
+        self.log.debug("take_action(%s)", parsed_args)
+
+        client = self.app.client_manager.reservation
+
+        columns = ALLOCATION_RESOURCE.fields
+        labels = ALLOCATION_RESOURCE.labels
+
+        params = {}
+        params["resource"] = 'os-hosts'
+
+        self.log.debug("params(%s)", params)
+        data = client.allocation.list(**params)
+
+        data = oscutils.sort_items(data, parsed_args.sort_by)
+
+        output_data = (
+            oscutils.get_dict_properties(
+                allocation_dict, columns, formatters=_formatters
+            )
+            for allocation_dict in data
+        )
+        return (labels, output_data)
 
 
 class ReallocateHost(command.ReallocateCommand):

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ ignore_basepython_conflict = True
 
 [testenv]
 basepython = python3
-install_command = pip install {opts} {packages}
 deps =
         -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2023.1}
        -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
draft PR which removes "manual" output formatting from blazarclient

TODO: actually use cliff's native formatting more effectively