### PR TITLE
fix BlazarClientException ignoring status code

### DIFF
--- a/blazarclient/exception.py
+++ b/blazarclient/exception.py
@@ -19,22 +19,21 @@ from blazarclient.i18n import _
 
 class BlazarClientException(Exception):
     """Base exception class."""
-    message = _("An unknown exception occurred %s.")
+    message_template = _("An unknown exception occurred %s.")
     code = 500
 
     def __init__(self, message=None, **kwargs):
-        self.kwargs = kwargs
+        if 'code' in kwargs:
+            self.code = kwargs['code']
+        else:
+            # ensure code in kwargs to template message
+            kwargs["code"]=self.code
+        if message:
+            self.message = message
+        else:
+            self.message = self.message_template % kwargs
 
-        if 'code' not in self.kwargs:
-            try:
-                self.kwargs['code'] = self.code
-            except AttributeError:
-                pass
-
-        if not message:
-            message = self.message % kwargs
-
-        super(BlazarClientException, self).__init__(message)
+        super(BlazarClientException, self).__init__(self.message)
 
 
 class CommandError(BlazarClientException):

--- a/blazarclient/tests/test_base.py
+++ b/blazarclient/tests/test_base.py
@@ -126,7 +126,24 @@ class RequestManagerTestCase(tests.TestCase):
         kwargs = {"body": {"req_key": "req_value"}}
         self.assertRaises(exception.BlazarClientException,
                           self.manager.request, url, "POST", **kwargs)
+        
+    @mock.patch('requests.request')
+    def test_request_fail_notfound(self, m):
 
+        m.return_value.status_code = 404
+        m.return_value.text = "{\"error_code\": 404, \"error_message\": \"Object with {'lease_id': 'aaa-bbb-ccc'} not found\", \"error_name\": 404}"
+        url = '/leases/aaa-bbb-ccc'
+
+        try:
+            resp, body = self.manager.get(url)
+        except exception.BlazarClientException as exc:
+            self.assertEqual(exc.code, 404)
+            print(exc)
+        else:
+            # Fail if we don't have the expected exception
+            # Hack because testtools doesn't support AssertRaises as context Manager
+            self.assertFalse(True)
+        m.assert_called_once()
 
 class SessionClientTestCase(tests.TestCase):
 


### PR DESCRIPTION
the base BlazarClientException class was never setting "self.code", even when passed as an argument. This led to any http exception, including 404, being reported as a 500 error.